### PR TITLE
force docker login in the samples to ensure that it will use the latest OLM index images

### DIFF
--- a/hack/backport/backport.go
+++ b/hack/backport/backport.go
@@ -63,6 +63,18 @@ func main() {
 		"registry.redhat.io/redhat/certified-operator-index:v4.5",
 	}
 
+	command = exec.Command("docker", "login", "https://registry.connect.redhat.com")
+	_, err = pkg.RunCommand(command)
+	if err != nil {
+		log.Errorf("running command :%s", err)
+	}
+
+	command = exec.Command("docker", "login", "https://registry.redhat.io")
+	_, err = pkg.RunCommand(command)
+	if err != nil {
+		log.Errorf("running command :%s", err)
+	}
+
 	for _, v := range allimages {
 
 		// create dir name with the image name only

--- a/hack/report/full.go
+++ b/hack/report/full.go
@@ -66,6 +66,18 @@ func main() {
 		"quay.io/operatorhubio/catalog:latest",
 	}
 
+	command = exec.Command("docker", "login", "https://registry.connect.redhat.com")
+	_, err = pkg.RunCommand(command)
+	if err != nil {
+		log.Errorf("running command :%s", err)
+	}
+
+	command = exec.Command("docker", "login", "https://registry.redhat.io")
+	_, err = pkg.RunCommand(command)
+	if err != nil {
+		log.Errorf("running command :%s", err)
+	}
+
 	for _, v := range allimages {
 
 		// create dir name with the image name only


### PR DESCRIPTION
**Description**
force docker login in the samples to ensure that it will use the latest OLM index images

**Motivation**
By checking a scenario with the CNV team we could identify that if we are not logged then is not possible to pull the latest version of the image and the reports will be generated by using an outdated version. 
