### PR TITLE
rename-bin-tool and fix run it outside of the cloned dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ help: ## Display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 ##@ Build
-
+GO_ASMFLAGS = -asmflags "all=-trimpath=$(shell dirname $(PWD))"
+GO_GCFLAGS = -gcflags "all=-trimpath=$(shell dirname $(PWD))"
 LD_FLAGS=-ldflags " \
     -X main.goos=$(shell go env GOOS) \
     -X main.goarch=$(shell go env GOARCH) \
@@ -37,10 +38,13 @@ LD_FLAGS=-ldflags " \
     "
 .PHONY: build
 build: ## Build the project locally
-	go build $(LD_FLAGS) -o bin/audit ./cmd
+	go build $(GO_GCFLAGS) $(GO_ASMFLAGS) $(LD_FLAGS) -o bin/audit-tool ./cmd
+	cp ./bin/audit-tool $(GOBIN)/audit-tool
 
-install: build ## Build and install the binary with the current source code. Use it to test your changes locally.
-	cp ./bin/audit $(GOBIN)/audit
+.PHONY: install
+install: ## Build the project locally
+	make build
+	cp ./bin/audit-tool $(GOBIN)/audit-tool
 
 ##@ Development
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ NOTE that you can run the reports without SDK and the cluster running with by us
 To get the project and install the binary:
 
 ```sh
-$ git clone git@github.com:camilamacedo86/audit.git
+$ git clone git@github.com:operator-framework/audit.git
 $ cd audit
 $ make install
 ```
@@ -50,19 +50,19 @@ docker login https://registry.redhat.io
 Now, you can audit all operator bundles of an image catalog with: 
 
 ```sh 
-./bin/audit bundles --index-image=registry.redhat.io/redhat/redhat--operator-index:v4.7 --head-only --output-path=testdata/xls
+audit-tool bundles --index-image=registry.redhat.io/redhat/redhat--operator-index:v4.7 --head-only --output-path=testdata/xls
 ```
 
 Now, you can audit all packages of an image catalog with: 
 
 ```sh 
-./bin/audit packages --index-image=registry.redhat.io/redhat/redhat--operator-index:v4.7 --output-path=testdata/xls
+audit-tool packages --index-image=registry.redhat.io/redhat/redhat--operator-index:v4.7 --output-path=testdata/xls
 ```
 
 Note that you can also output the results in JSON format:
 
 ```sh 
-./bin/audit bundles index \
+audit-tool bundles index \
     --index-image=registry.redhat.io/redhat/redhat-operator-index:v4.7 \
     --limit=3 \
     --head-only \
@@ -75,7 +75,7 @@ Note that you can also output the results in JSON format:
 Use the `--help` flag to check the options and the further information about its commands. Following an example:
 
 ```sh
-$ ./bin/audit bundles --help
+$ audit-tool bundles --help
 Provides reports with the details of all bundles operators ship in the index image informed according to the criteria defined via the flags.
 
  **When this report is useful?** 
@@ -83,7 +83,7 @@ Provides reports with the details of all bundles operators ship in the index ima
 This report is useful when is required to check the operator bundles details.
 
 Usage:
-  audit bundles [flags]
+  audit-tool bundles [flags]
 
 Flags:
       --disable-scorecard    if set, will disable the scorecard tests

--- a/cmd/bundles/command.go
+++ b/cmd/bundles/command.go
@@ -137,6 +137,10 @@ func indexRun(cmd *cobra.Command, args []string) error {
 	command = exec.Command("rm", "-rf", "tmp")
 	_, _ = pkg.RunCommand(command)
 
+	// Cleanup
+	command = exec.Command("rm", "-rf", "output")
+	_, _ = pkg.RunCommand(command)
+
 	log.Infof("Start to generate the reportData")
 	if err := reportData.OutputReport(); err != nil {
 		return err
@@ -156,6 +160,12 @@ func extractIndexDB() error {
 	_, err := pkg.RunCommand(command)
 	if err != nil {
 		return fmt.Errorf("unable to create container image %s : %s", flags.IndexImage, err)
+	}
+
+	command = exec.Command("mkdir", "output")
+	_, err = pkg.RunCommand(command)
+	if err != nil {
+		return fmt.Errorf("unable to extract the image for index.db %s : %s", flags.IndexImage, err)
 	}
 
 	// Extract

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,7 +27,7 @@ import (
 func main() {
 
 	rootCmd := &cobra.Command{
-		Use:   "audit",
+		Use:   "audit-tool",
 		Short: "An analytic tool to audit operator bundles and index catalogs",
 		Long: "The audit is an analytic tool which uses the Operator Framework solutions. " +
 			"More info: https://github.com/operator-framework/audit",


### PR DESCRIPTION
**Description**
- Rename bin tool from audit to audit-tool
- Fix the binary works outside of the cloned directory

**Motivation**
OSX systems have in the sbin a bin called audit which generates a conflict to install the bin locally

