### PR TITLE
fix check to value of max ocp version

### DIFF
--- a/pkg/removed_apis.go
+++ b/pkg/removed_apis.go
@@ -124,16 +124,12 @@ func RemovedAPIsKind(deprecatedAPIs map[string][]string) []string {
 // OCP version where the apis v1beta1 is no longer supported
 const ocpVerV1beta1Unsupported = "4.9"
 
-// IsComplyingWithDeprecatedCriteria will verify if the OpenShiftVersion property was informed as the OCP label index
-// For audit we have not the dockerfile so we are checking by here.
-func IsComplyingWithDeprecatedCriteria(maxOCPVersion, ocpLabel string) bool {
-	return IsMaxOCPVersionLowerThan49(maxOCPVersion) && IsOcpLabelRangeLowerThan49(ocpLabel)
-}
-
 func IsMaxOCPVersionLowerThan49(maxOCPVersion string) bool {
 	if len(maxOCPVersion) == 0 {
 		return false
 	}
+
+	maxOCPVersion = strings.ReplaceAll(maxOCPVersion, "\"", "")
 	semVerVersionMaxOcp, err := semver.ParseTolerant(maxOCPVersion)
 	if err != nil {
 		return false


### PR DESCRIPTION
By doing the work in the community operator we could check that when the property is set by the user with:

```
"olm.properties": '[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]'
```

Opm will add the value with the double cotes. That also needs to be solved in the validator. 

IMPORTANT: it was not identified before because in the @gallettilance scripts we are inserting it directly and without the double coutes. However, that is not how opm will set the value when it is provided by the user. 