### PR TITLE
fix: remove duplicates from output of helpers to deprecate bundles from 4.9

### DIFF
--- a/hack/scripts/deprecated-bundles-repo/deprecate-all/deprecated_index.go
+++ b/hack/scripts/deprecated-bundles-repo/deprecate-all/deprecated_index.go
@@ -167,6 +167,19 @@ func main() {
 		})
 
 		for _, b := range bundles {
+
+			// not set duplicates when the bundle is more than one channel
+			// for example.
+			found := false
+			for _, allD := range deprecatedYaml.Bundles {
+				if allD.Details == b.BundleName {
+					found = true
+				}
+			}
+			if found {
+				continue
+			}
+
 			// We just ONLY the bundles which are using the removed APIS
 			if len(b.KindsDeprecateAPIs) > 0 && len(b.DeprecateAPIsManifests[pkg.Unknown]) == 0 {
 				deprecatedYaml.Bundles = append(deprecatedYaml.Bundles,

--- a/hack/scripts/deprecated-bundles-repo/deprecate-green/deprecated_index.go
+++ b/hack/scripts/deprecated-bundles-repo/deprecate-green/deprecated_index.go
@@ -198,6 +198,19 @@ func main() {
 		})
 
 		for _, b := range bundles {
+
+			// not set duplicates when the bundle is more than one channel
+			// for example.
+			found := false
+			for _, allD := range deprecatedYaml.Bundles {
+				if allD.Details == b.BundleName {
+					found = true
+				}
+			}
+			if found {
+				continue
+			}
+
 			// We just ONLY the bundles which are using the removed APIS
 			if len(b.KindsDeprecateAPIs) > 0 && len(b.DeprecateAPIsManifests[pkg.Unknown]) == 0 {
 				deprecatedYaml.Bundles = append(deprecatedYaml.Bundles,
@@ -207,6 +220,7 @@ func main() {
 					})
 			}
 		}
+
 		allDeprecated = append(allDeprecated, deprecatedYaml)
 	}
 


### PR DESCRIPTION
The pkg might have the same bundle in more than one channel. 
In this case, we cannot add more than once the bundle otherwise the iib process to deprecate will fail. 