### PR TITLE
feat: Add specific needs script to generate RBAC Deamonsets/Node APIs report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@
 
 # skip files used locally that cannot be commited
 **/testdata/reports/**/validator/**
+
+# The following directory is ignored since it is used
+# to genertae reports for specifc needs
+# More info : /hack/specific-needs/rbac/generate.go
+**/testdata/reports/rbac/**

--- a/hack/specific-needs/rbac/generate.go
+++ b/hack/specific-needs/rbac/generate.go
@@ -1,0 +1,377 @@
+// Copyright 2022 The Audit Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This script when execute look for all bundles index reports generates under
+// testdata reports and inside of the each image directory so that can obtain
+// the required data to generate its report.
+//
+// This report looks for list Packages and its bundles which are requesting
+// create/update/patch permissions for node and node/status API. Also, this report
+// looks for all scenarios which has RBCA permission to create/update/patch deamonsets.
+//
+// It might be removed in the future or become to be some kind of workflow check.
+package main
+
+import (
+	"fmt"
+	"html/template"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/goccy/go-yaml"
+	"github.com/operator-framework/audit/hack"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/audit/pkg"
+	"github.com/operator-framework/audit/pkg/reports/bundles"
+	"github.com/operator-framework/audit/pkg/reports/custom"
+)
+
+type Bundle struct {
+	BundleName         string
+	ForHideButton      string
+	Permissions        string
+	ClusterPermissions string
+}
+
+type Package struct {
+	PackageName string
+	Bundles     []Bundle
+}
+
+type RBACReport struct {
+	ImageName   string
+	ImageID     string
+	ImageHash   string
+	ImageBuild  string
+	GeneratedAt string
+	Nodes       []Package
+	Daemonset   []Package
+}
+
+func main() {
+	log.Info("Starting ...")
+
+	currentPath, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	reportPath := filepath.Join(currentPath, hack.ReportsPath, "rbac")
+
+	command := exec.Command("rm", "-rf", reportPath)
+	_, err = pkg.RunCommand(command)
+	if err != nil {
+		log.Errorf("running command :%s", err)
+	}
+
+	command = exec.Command("mkdir", reportPath)
+	_, err = pkg.RunCommand(command)
+	if err != nil {
+		log.Errorf("running command :%s", err)
+	}
+
+	custom.Flags.OutputPath = reportPath
+
+	dirs := map[string]string{
+		"redhat_certified_operator_index": "registry.redhat.io/redhat/certified-operator-index",
+		"redhat_community_operator_index": "registry.redhat.io/redhat/community-operator-index",
+		"redhat_redhat_marketplace_index": "registry.redhat.io/redhat/redhat-marketplace-index",
+		"redhat_redhat_operator_index":    "registry.redhat.io/redhat/redhat-operator-index",
+	}
+
+	allPaths := []string{}
+	// nolint:scopelint
+	for dir := range dirs {
+		pathToWalk := filepath.Join(currentPath, hack.ReportsPath, dir)
+		if _, err := os.Stat(pathToWalk); err != nil && os.IsNotExist(err) {
+			continue
+		}
+
+		// Walk in the testdata dir and generates the deprecated-api custom dashboard for
+		// all bundles JSON reports available there
+
+		err := filepath.Walk(pathToWalk, func(path string, info os.FileInfo, err error) error {
+			if info != nil && !info.IsDir() && strings.HasPrefix(info.Name(), "bundles") &&
+				strings.HasSuffix(info.Name(), "json") {
+				allPaths = append(allPaths, path)
+			}
+			return nil
+		})
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	for _, v := range allPaths {
+		custom.Flags.File = v
+		err = generateReportFor()
+		if err != nil {
+			log.Error(err)
+		}
+	}
+
+	log.Infof("Operation completed.")
+}
+
+func generateReportFor() error {
+	bundles, err := custom.ParseBundlesJSONReport()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	report := generateRBACReport(bundles)
+
+	dashOutputPath := filepath.Join(custom.Flags.OutputPath,
+		pkg.GetReportName(report.ImageName, "rbac", "html"))
+
+	f, err := os.Create(dashOutputPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if len(custom.Flags.Template) == 0 {
+		custom.Flags.Template = getTemplatePath()
+	}
+
+	t := template.Must(template.ParseFiles(custom.Flags.Template))
+	err = t.Execute(f, report)
+	if err != nil {
+		panic(err)
+	}
+
+	return f.Close()
+}
+
+// todo: this template requires to be embed
+func getTemplatePath() string {
+	currentPath, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+	return filepath.Join(currentPath, "/hack/specific-needs/rbac/template.go.tmpl")
+}
+
+func generateRBACReport(bundlesReport bundles.Report) *RBACReport {
+	rbacReport := &RBACReport{}
+	rbacReport.ImageName = bundlesReport.Flags.IndexImage
+	rbacReport.ImageID = bundlesReport.IndexImageInspect.ID
+	rbacReport.ImageBuild = bundlesReport.IndexImageInspect.Created
+	rbacReport.GeneratedAt = bundlesReport.GenerateAt
+
+	allBundlesWithNode := getAllWithRBACForNodes(bundlesReport)
+	allBundlesWithDeamonset := getAllBundlesWithRBACForDeamonset(bundlesReport)
+
+	pkgWithNodes := mapBundlesPerPackage(allBundlesWithNode)
+	pkgsWithDeamonset := mapBundlesPerPackage(allBundlesWithDeamonset)
+
+	for pkgName, bundles := range pkgWithNodes {
+		nodeBundles := getReportValues(bundles)
+		rbacReport.Nodes = append(rbacReport.Nodes, Package{
+			PackageName: pkgName,
+			Bundles:     nodeBundles,
+		})
+	}
+
+	for pkgName, bundles := range pkgsWithDeamonset {
+		deamonsetBundles := getReportValues(bundles)
+		rbacReport.Daemonset = append(rbacReport.Nodes, Package{
+			PackageName: pkgName,
+			Bundles:     deamonsetBundles,
+		})
+	}
+
+	return rbacReport
+}
+
+func getReportValues(bundlesColum []bundles.Column) []Bundle {
+	var bundlesResult []Bundle
+	for _, bundle := range bundlesColum {
+
+		perm := ""
+		if bundle.BundleCSV.Spec.InstallStrategy.StrategySpec.Permissions != nil {
+			permYAML, err := yaml.Marshal(bundle.BundleCSV.Spec.InstallStrategy.StrategySpec.Permissions)
+			if err != nil {
+				log.Fatalf(err.Error())
+			}
+			perm = fmt.Sprintf("\n%s\n\n", string(permYAML))
+		}
+
+		clusterPerm := ""
+		if bundle.BundleCSV.Spec.InstallStrategy.StrategySpec.ClusterPermissions != nil {
+			permYAML, err := yaml.Marshal(bundle.BundleCSV.Spec.InstallStrategy.StrategySpec.ClusterPermissions)
+			if err != nil {
+				log.Fatalf(err.Error())
+			}
+
+			clusterPerm = fmt.Sprintf("\n%s\n\n", string(permYAML))
+		}
+
+		namehidden := bundle.BundleCSV.Name
+		namehidden = strings.Replace(namehidden, "_", "", -1)
+		namehidden = strings.Replace(namehidden, ".", "", -1)
+		namehidden = strings.Replace(namehidden, "-", "", -1)
+		bundlesResult = append(bundlesResult, Bundle{BundleName: bundle.BundleCSV.Name,
+			Permissions:        perm,
+			ClusterPermissions: clusterPerm,
+			ForHideButton:      namehidden,
+		})
+	}
+
+	sort.Slice(bundlesResult[:], func(i, j int) bool {
+		return bundlesResult[i].BundleName < bundlesResult[j].BundleName
+	})
+
+	return bundlesResult
+}
+
+func mapBundlesPerPackage(bundlesReport []bundles.Column) map[string][]bundles.Column {
+	mapPackagesWithBundles := make(map[string][]bundles.Column)
+	for _, v := range bundlesReport {
+		if len(v.PackageName) == 0 {
+			continue
+		}
+		mapPackagesWithBundles[v.PackageName] = append(mapPackagesWithBundles[v.PackageName], v)
+	}
+	return mapPackagesWithBundles
+}
+
+//nolint: dupl
+func getAllBundlesWithRBACForDeamonset(bundlesReport bundles.Report) []bundles.Column {
+	var allBundlesWithDeamonsets []bundles.Column
+	for _, bundle := range bundlesReport.Columns {
+		found := false
+		if bundle.BundleCSV == nil {
+			continue
+		}
+		if bundle.IsDeprecated {
+			continue
+		}
+		if len(bundle.PackageName) == 0 {
+			continue
+		}
+		if bundle.BundleCSV.Spec.InstallStrategy.StrategySpec.Permissions != nil {
+			for _, perms := range bundle.BundleCSV.Spec.InstallStrategy.StrategySpec.Permissions {
+				if hasBundleDaemonsetsCriteria(perms) {
+					allBundlesWithDeamonsets = append(allBundlesWithDeamonsets, bundle)
+					found = true
+					break
+				}
+			}
+		}
+		if found {
+			continue
+		}
+		if bundle.BundleCSV.Spec.InstallStrategy.StrategySpec.ClusterPermissions != nil {
+			for _, perms := range bundle.BundleCSV.Spec.InstallStrategy.StrategySpec.ClusterPermissions {
+				if hasBundleDaemonsetsCriteria(perms) {
+					allBundlesWithDeamonsets = append(allBundlesWithDeamonsets, bundle)
+					break
+				}
+			}
+		}
+	}
+	return allBundlesWithDeamonsets
+}
+
+//nolint:dupl
+func getAllWithRBACForNodes(bundlesReport bundles.Report) []bundles.Column {
+	var allBundlesWithNode []bundles.Column
+
+	for _, bundle := range bundlesReport.Columns {
+		foundNode := false
+		if bundle.BundleCSV == nil {
+			continue
+		}
+		if bundle.IsDeprecated {
+			continue
+		}
+		if len(bundle.PackageName) == 0 {
+			continue
+		}
+		if bundle.BundleCSV.Spec.InstallStrategy.StrategySpec.Permissions != nil {
+			for _, perms := range bundle.BundleCSV.Spec.InstallStrategy.StrategySpec.Permissions {
+				if hasBundleNodeCriteria(perms) {
+					allBundlesWithNode = append(allBundlesWithNode, bundle)
+					foundNode = true
+					break
+				}
+			}
+		}
+		if foundNode {
+			continue
+		}
+		if bundle.BundleCSV.Spec.InstallStrategy.StrategySpec.ClusterPermissions != nil {
+			for _, perms := range bundle.BundleCSV.Spec.InstallStrategy.StrategySpec.ClusterPermissions {
+				if hasBundleNodeCriteria(perms) {
+					allBundlesWithNode = append(allBundlesWithNode, bundle)
+					break
+				}
+			}
+		}
+	}
+	return allBundlesWithNode
+}
+
+func hasBundleDaemonsetsCriteria(perms v1alpha1.StrategyDeploymentPermissions) bool {
+	if perms.Rules != nil {
+		for _, rule := range perms.Rules {
+			for _, names := range rule.Resources {
+				if names == "daemonsets" {
+					if rule.Verbs == nil {
+						continue
+					}
+					for _, verb := range rule.Verbs {
+						if checkForWritingPermissions(verb) {
+							return true
+						}
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+func hasBundleNodeCriteria(perms v1alpha1.StrategyDeploymentPermissions) bool {
+	if perms.Rules != nil {
+		for _, rule := range perms.Rules {
+			for _, names := range rule.Resources {
+				if names == "nodes" || names == "nodes/status" {
+					if rule.Verbs == nil {
+						continue
+					}
+					for _, verb := range rule.Verbs {
+						if checkForWritingPermissions(verb) {
+							return true
+						}
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+func checkForWritingPermissions(verb string) bool {
+	return verb == "create" ||
+		verb == "patch" ||
+		verb == "update" ||
+		verb == "*"
+}

--- a/hack/specific-needs/rbac/template.go.tmpl
+++ b/hack/specific-needs/rbac/template.go.tmpl
@@ -1,0 +1,290 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <title>RBAC writing permissions (Nodes and Daemonsets)</title>
+
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/dt-1.10.24/datatables.min.css"/>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-+0n0xVW2eSR5OomGNYDnhzAbDsOXxcvSN1TPprVMTNDbiYZCxYbOOl7+AMvyTG2x" crossorigin="anonymous">
+
+
+    <style>
+        div.dataTables_wrapper {
+            width: 98%;
+            margin: 0 auto;
+        }
+
+        table.minimalistBlack {
+            border: 3px solid #000000;
+        }
+        table.minimalistBlack td, table.minimalistBlack th {
+            border: 1px solid #000000;
+            font-size: 12px;
+            text-align: left;
+        }
+        table.minimalistBlack tbody td {
+            font-size: 12px;
+        }
+        table.minimalistBlack thead {
+            border-bottom: 3px solid #000000;
+            text-align: center;
+        }
+        table.minimalistBlack thead th {
+            font-size: 15px;
+            color: white;
+            text-align: center;
+        }
+
+        .themed-container {
+            padding: .75rem;
+            margin-bottom: 1.5rem;
+            background-color: #F0F0F0;
+            border: 1px solid #0D0C0C;
+        }
+    </style>
+
+
+</head>
+<body class="py-4">
+
+<script type="text/javascript" src="https://cdn.datatables.net/v/dt/dt-1.10.24/datatables.min.js"></script>
+<script type="text/javascript" src="https://code.jquery.com/jquery-3.5.1.js"></script>
+<script type="text/javascript" src="https://cdn.datatables.net/1.10.24/js/jquery.dataTables.min.js"></script>
+
+<!-- Option 1: Bootstrap Bundle with Popper -->
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-gtEjrD/SeCtmISkJkNUaaKMoLD0//ElJ19smozuHV6z3Iehds+3Ulb9Bn9Plx0x4" crossorigin="anonymous"></script>
+
+<script >
+
+    $(document).ready(function() {
+        $('#grade').DataTable( {
+            "scrollX": true
+        } );
+    } );
+
+</script>
+
+<main>
+
+        <h1>RBAC writing permissions (Nodes and Daemonsets)</h1>
+        <p>The following packages were obtained by checking the image and the bundle manifests distributed. This report aims to try to identify the package distributions that are asking permissions to writing on nodes AND those ones which are asking permissions to write Daemonsets resources.</p>
+
+        <div class="container-fluid themed-container">
+            <h5 class="display-12 fw-bold">Data from the image used</h5>
+            <ul>
+                <li>Image name: {{ .ImageName }} </li>
+                <li>Image ID: {{ .ImageID }} </li>
+                <li>Image Created at: {{ .ImageBuild }} </li>
+                <li>From JSON report generated at: {{ .GeneratedAt }} </li>
+            </ul>
+        </div>
+
+        <div class="container-fluid themed-container">
+            <h5 class="display-12 fw-bold">FAQ</h5>
+            <li> <b>Cluster Permissions:</b> Contains all clusters permissions configured on the Operator (e.g. see <a href="https://github.com/operator-framework/operator-sdk/blob/v1.18.1/testdata/go/v3/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml#L37-L97">here</a> an example). These permissions will be used to install Cluster Roles and Cluster Roles Binding</li>
+            <li> <b>Role Permissions:</b> Contains all permissions configured on the Operator (e.g. see <a href="https://github.com/operator-framework/operator-sdk/blob/v1.18.1/testdata/go/v3/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml#L169-L202">here</a> an example). These permissions will be used to install Roles and Roles Binding</li>
+        </div>
+
+           <div class="container-fluid themed-container">
+                  <h5 class="display-12 fw-bold">Writing Nodes</h5>
+                  <p> Following the packages with its bundles which were founding requesting RBAC to create OR update OR patch OR for all with (*) for Nodes OR nodes/status resources.</p>
+                  <table id="list" class="minimalistBlack" style="background-color: dimgrey; width: 98%">
+                      <thead>
+                          <tr>
+                             <th>Package Name</th>
+                             <th>Bundles Details</th>
+                         </tr>
+                    </thead>
+                    <tbody style="background-color: white;">
+                    {{ with .Nodes }}
+                        {{ range . }}
+                             <tr>
+                             <th>{{ .PackageName }}</th>
+                             <th>
+                              <div class="container-fluid themed-container">
+                             <table id="nodes-{{ .PackageName }}" class="minimalistBlack" style="width: 100%">
+                                 <thead>
+                                  <tr style="background-color: #004C99;">
+                                       <th align="center"> Name </th>
+                                       <th align="center">Cluster Permissions</th>
+                                       <th align="center">Role Permissions</th>
+                                  </tr>
+                                 </thead>
+                                 <tbody>
+                                 {{ with .Bundles }}
+                                      {{ range . }}
+                                      <tr>
+                                          <th>{{ .BundleName}} </th>
+                                          <th align="center">
+                                          {{ if eq (len .ClusterPermissions) 0 }}
+                                               <div align="center">
+                                                <p> - </p>
+                                                </div>
+                                          {{ end }}
+                                          {{ if gt (len .ClusterPermissions) 0 }}
+                                            <script>
+                                              function myFunctionShowNodeCluster(value) {
+                                                  var x = document.getElementById(value);
+                                                  if (x.style.display === "none") {
+                                                    x.style.display = "block";
+                                                  } else {
+                                                    x.style.display = "none";
+                                                  }
+                                                }
+                                            </script>
+                                            <div align="center">
+                                                <button align="center" onclick="myFunctionShowNodeCluster('show-node-cluster-{{ .ForHideButton}}')">Show Details</button>
+                                            </div>
+                                            <div id="show-node-cluster-{{ .ForHideButton}}" style="display: none;">
+                                                <pre>
+                                                <code> {{ .ClusterPermissions}} </code>
+                                                </pre>
+                                            </div>
+                                            {{ end }}
+                                          </th>
+                                          <th align="center">
+                                           {{ if eq (len .Permissions) 0 }}
+                                                 <div align="center">
+                                                 <p> - </p>
+                                                 </div>
+                                           {{ end }}
+                                          {{ if gt (len .Permissions) 0 }}
+                                            <script>
+                                              function myFunctionShowNodePermissions(value) {
+                                                  var x = document.getElementById(value);
+                                                  if (x.style.display === "none") {
+                                                    x.style.display = "block";
+                                                  } else {
+                                                    x.style.display = "none";
+                                                  }
+                                                }
+                                            </script>
+                                            <div align="center">
+                                                <button align="center" onclick="myFunctionShowNodePermissions('node-show-node-perm-{{ .ForHideButton}}')">Show Details</button>
+                                            </div>
+                                            <div id="node-show-node-perm-{{ .ForHideButton}}" style="display: none;">
+                                                <pre>
+                                                <code> {{ .Permissions}} </code>
+                                                </pre>
+                                            </div>
+                                            {{ end }}
+                                      </tr>
+                                 {{ end }}
+                             {{ end }}
+                             </tbody>
+                             </table>
+                             </div>
+                             </th>
+                         </tr>
+                            {{ end }}
+                        {{ end }}
+                        </tbody>
+                    </table>
+                </div>
+
+
+           <div class="container-fluid themed-container">
+                  <h5 class="display-12 fw-bold">Writing Daemonsets</h5>
+                  <p> Following the packages with its bundles which were founding requesting RBAC to create OR update OR patch OR for all with (*) for Daemonsets resources.</p>
+                  <table id="list" class="minimalistBlack" style="background-color: dimgrey; width: 98%">
+                      <thead>
+                          <tr>
+                             <th>Package Name</th>
+                             <th>Bundles Details</th>
+                         </tr>
+                    </thead>
+                    <tbody style="background-color: white;">
+                    {{ with .Daemonset }}
+                        {{ range . }}
+                             <tr>
+                             <th>{{ .PackageName }}</th>
+                             <th>
+                              <div class="container-fluid themed-container">
+                             <table id="nodes-{{ .PackageName }}" class="minimalistBlack" style="width: 100%">
+                                 <thead>
+                                  <tr style="background-color: #004C99;">
+                                       <th align="center"> Name </th>
+                                       <th align="center">Cluster Permissions</th>
+                                       <th align="center">Role Permissions</th>
+                                  </tr>
+                                 </thead>
+                                 <tbody>
+                                 {{ with .Bundles }}
+                                      {{ range . }}
+                                      <tr>
+                                          <th>{{ .BundleName}} </th>
+                                          <th align="center">
+                                           {{ if eq (len .ClusterPermissions) 0 }}
+                                                 <div align="center">
+                                                 <p> - </p>
+                                                 </div>
+                                            {{ end }}
+                                            {{ if gt (len .ClusterPermissions) 0 }}
+                                            <script>
+                                              function myFunctionShowDeamonsetCluster(value) {
+                                                  var x = document.getElementById(value);
+                                                  if (x.style.display === "none") {
+                                                    x.style.display = "block";
+                                                  } else {
+                                                    x.style.display = "none";
+                                                  }
+                                                }
+                                            </script>
+                                            <div align="center">
+                                            <button align="center" onclick="myFunctionShowDeamonsetCluster('show-deamonset-cluster-{{ .ForHideButton}}')">Show Details</button>
+                                            </div>
+                                            <div  id="show-deamonset-cluster-{{ .ForHideButton}}" style="display: none;">
+                                                <pre>
+                                                <code> {{ .ClusterPermissions}} </code>
+                                                </pre>
+                                            </div>
+                                             {{ end }}
+                                          </th>
+                                          <th align="center">
+                                          {{ if eq (len .Permissions) 0 }}
+                                               <div align="center">
+                                                <p> - </p>
+                                                </div>
+                                          {{ end }}
+                                          {{ if gt (len .Permissions) 0 }}
+                                            <script>
+                                              function myFunctionShowDeamonsetPermissions(value) {
+                                                  var x = document.getElementById(value);
+                                                  if (x.style.display === "none") {
+                                                    x.style.display = "block";
+                                                  } else {
+                                                    x.style.display = "none";
+                                                  }
+                                                }
+                                            </script>
+                                            <div align="center">
+                                            <button align="center" onclick="myFunctionShowDeamonsetPermissions('show-deamonset-perm-{{ .ForHideButton}}')">Show Details</button>
+                                            </div>
+                                            <div id="show-deamonset-perm-{{ .ForHideButton}}" style="display: none;">
+                                                <pre>
+                                                <code> {{ .Permissions}} </code>
+                                                </pre>
+                                            </div>
+                                             {{ end }}
+                                      </tr>
+                                 {{ end }}
+                             {{ end }}
+                             </tbody>
+                             </table>
+                             </div>
+                             </th>
+                         </tr>
+                            {{ end }}
+                        {{ end }}
+                        </tbody>
+                    </table>
+                </div>
+</main>
+
+</body>
+</html>


### PR DESCRIPTION
**Description**
This PR adds a script for a script need which generates reports with some criteria based on RBAC
It is stored only in case we need to look for this script in the future.
However, it also might be removed in the long way. 