### PR TITLE
:bug: fix option to remove bundles images by using containerEng informed when run bundles reports

### DIFF
--- a/hack/report/bundles/generate.go
+++ b/hack/report/bundles/generate.go
@@ -78,6 +78,7 @@ func main() {
 			command := exec.Command(binPath, "index", report,
 				fmt.Sprintf("--index-image=%s", image),
 				fmt.Sprintf("--output-path=%s", reportPathName),
+				"--server-mode", // for not remove bundles images
 			)
 			hack.RunCommandCapturingOutput(command)
 		}
@@ -119,6 +120,7 @@ func main() {
 				fmt.Sprintf("--index-image=%s", image),
 				"--output=json",
 				"--disable-scorecard",
+				"--server-mode", // for not remove bundles images
 				fmt.Sprintf("--output-path=%s", reportPathName),
 			)
 

--- a/pkg/actions/get_bundle.go
+++ b/pkg/actions/get_bundle.go
@@ -120,7 +120,7 @@ func GetDataFromBundleImage(auditBundle *models.AuditBundle,
 
 	}
 
-	cleanupBundleDir(auditBundle, bundleDir, serverMode)
+	cleanupBundleDir(auditBundle, bundleDir, serverMode, containerEngine)
 
 	return auditBundle
 }
@@ -219,12 +219,12 @@ func extractBundleFromImage(auditBundle *models.AuditBundle, bundleDir string, c
 	_, _ = pkg.RunCommand(cmd)
 }
 
-func cleanupBundleDir(auditBundle *models.AuditBundle, dir string, serverMode bool) {
+func cleanupBundleDir(auditBundle *models.AuditBundle, dir string, serverMode bool, containerEngine string) {
 	cmd := exec.Command("rm", "-rf", dir)
 	_, _ = pkg.RunCommand(cmd)
 
 	if !serverMode {
-		cmd = exec.Command("podman", "rmi", auditBundle.OperatorBundleImagePath)
+		cmd = exec.Command(containerEngine, "rmi", auditBundle.OperatorBundleImagePath)
 		_, _ = pkg.RunCommand(cmd)
 	}
 }


### PR DESCRIPTION
**Description**
Ensure that eng informed ( docker or podman ) will be used
Ensure that hack scripts run in servermode 