### PR TITLE
Fix: maxOCP ordering and version format

### DIFF
--- a/cmd/index/eus/command.go
+++ b/cmd/index/eus/command.go
@@ -395,7 +395,7 @@ func getChannelsDefaultChannelHeadBundle(modelOrDb interface{}, operatorName str
 
 func getVersion(bundleName string) string {
 	version := strings.Join(strings.Split(bundleName, ".")[1:], ".")
-	return version
+	return removeVee(stripQuotes([]byte(version)))
 }
 
 func getNonHeadBundles(modelOrDb interface{}, grouping channelGrouping) [][]string {
@@ -576,4 +576,8 @@ func stripQuotes(data []byte) string {
 		data = data[1 : len(data)-1]
 	}
 	return string(data)
+}
+
+func removeVee(s string) string {
+	return strings.Replace(s, "v", "", 1)
 }

--- a/cmd/index/eus/command.go
+++ b/cmd/index/eus/command.go
@@ -429,7 +429,6 @@ func getNonHeadBundles(modelOrDb interface{}, grouping channelGrouping) [][]stri
 	case model.Model:
 		for _, Package := range modelOrDb {
 			if Package.Name == grouping.OperatorName {
-				i := 0
 				for _, Channel := range Package.Channels {
 					var nonHeadBundleNamesPerChannel []string
 					for _, bundle := range Channel.Bundles {
@@ -437,14 +436,22 @@ func getNonHeadBundles(modelOrDb interface{}, grouping channelGrouping) [][]stri
 					}
 					headBundle, _ := Channel.Head()
 					nonHeadBundleNamesPerChannel = remove(nonHeadBundleNamesPerChannel, headBundle.Name)
-					nonHeadBundleNames[i] = nonHeadBundleNamesPerChannel
-					i++
+					nonHeadBundleNames[indexOf(Channel.Name, grouping.ChannelNames)] = nonHeadBundleNamesPerChannel
 				}
 			}
 		}
 		return nonHeadBundleNames
 	}
 	return nonHeadBundleNames
+}
+
+func indexOf(word string, data []string) int {
+	for k, v := range data {
+		if word == v {
+			return k
+		}
+	}
+	return -1
 }
 
 func remove(nonHeadBundles []string, headBundle string) []string {

--- a/cmd/index/eus/command.go
+++ b/cmd/index/eus/command.go
@@ -126,6 +126,10 @@ func run(cmd *cobra.Command, args []string) error {
 			EUSReportColumn = append(EUSReportColumn, channelGrouping)
 		}
 		EUSReportTable = append(EUSReportTable, EUSReportColumn)
+
+		// must rm container so all rmi succeed
+		command := exec.Command(flags.ContainerEngine, "rm", actions.CatalogIndex)
+		_, _ = pkg.RunCommand(command)
 		// always remove catalog images, so always non-"server-mode" as elsewhere
 		rmiCmd := exec.Command(flags.ContainerEngine, "rmi", flags.Indexes[index])
 		_, _ = pkg.RunCommand(rmiCmd)

--- a/cmd/index/eus/command.go
+++ b/cmd/index/eus/command.go
@@ -408,7 +408,8 @@ func getNonHeadBundles(modelOrDb interface{}, grouping channelGrouping) [][]stri
 				FROM operatorbundle 
 				INNER JOIN channel_entry 
 				ON operatorbundle.name=channel_entry.operatorbundle_name 
-				WHERE channel_entry.package_name = ? AND channel_entry.channel_name = ?;`
+				WHERE channel_entry.package_name = ? AND channel_entry.channel_name = ?
+				GROUP BY operatorbundle.name;`
 			row, err := modelOrDb.Query(sql, grouping.OperatorName, channelName)
 			if err != nil {
 				log.Errorf("unable to query the index db for maxOCPs : %s", err)

--- a/cmd/index/eus/command.go
+++ b/cmd/index/eus/command.go
@@ -465,7 +465,7 @@ func remove(nonHeadBundles []string, headBundle string) []string {
 }
 
 func getMaxOcp(modelOrDb interface{}, channelGrouping channelGrouping) []string {
-	var maxOcpPerChannel []string
+	maxOcpPerChannel := make([]string, len(channelGrouping.ChannelNames))
 	switch modelOrDb := modelOrDb.(type) {
 	case *sql.DB:
 		for _, channelHead := range channelGrouping.HeadBundleNames {
@@ -489,7 +489,6 @@ func getMaxOcp(modelOrDb interface{}, channelGrouping channelGrouping) []string 
 			row.Close()
 		}
 		return maxOcpPerChannel
-	//TODO debug on 4.11 and verify FBC results are same as SQL here
 	case model.Model:
 		for _, Package := range modelOrDb {
 			if Package.Name == channelGrouping.OperatorName {
@@ -503,7 +502,7 @@ func getMaxOcp(modelOrDb interface{}, channelGrouping channelGrouping) []string 
 							}
 						}
 					}
-					maxOcpPerChannel = append(maxOcpPerChannel, maxOpenShiftVersion)
+					maxOcpPerChannel[indexOf(Channel.Name, channelGrouping.ChannelNames)] = maxOpenShiftVersion
 				}
 			}
 		}

--- a/pkg/actions/extract_index.go
+++ b/pkg/actions/extract_index.go
@@ -23,16 +23,16 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const catalogIndex = "audit-catalog-index"
+const CatalogIndex = "audit-catalog-index"
 
 func ExtractIndexDBorCatalogs(image string, containerEngine string) error {
 	log.Info("Extracting database...")
 	// Remove image if exists already
-	command := exec.Command(containerEngine, "rm", catalogIndex)
+	command := exec.Command(containerEngine, "rm", CatalogIndex)
 	_, _ = pkg.RunCommand(command)
 
 	// Download the image
-	command = exec.Command(containerEngine, "create", "--name", catalogIndex, image, "\"yes\"")
+	command = exec.Command(containerEngine, "create", "--name", CatalogIndex, image, "\"yes\"")
 	_, err := pkg.RunCommand(command)
 	if err != nil {
 		return fmt.Errorf("unable to create container image %s : %s", image, err)
@@ -47,7 +47,7 @@ func ExtractIndexDBorCatalogs(image string, containerEngine string) error {
 		log.Fatal(err)
 	}
 	// sqlite db
-	command = exec.Command(containerEngine, "cp", fmt.Sprintf("%s:/database/index.db", catalogIndex),
+	command = exec.Command(containerEngine, "cp", fmt.Sprintf("%s:/database/index.db", CatalogIndex),
 		"./output/"+versionTag+"/")
 	_, err = pkg.RunCommand(command)
 	if err != nil {
@@ -55,13 +55,13 @@ func ExtractIndexDBorCatalogs(image string, containerEngine string) error {
 	}
 	// transitional indexes have a hidden sqlite db, copy it, and change the name to just index.db
 	command = exec.Command(containerEngine, "cp",
-		fmt.Sprintf("%s:/var/lib/iib/_hidden/do.not.edit.db", catalogIndex), "./output/"+versionTag+"/index.db")
+		fmt.Sprintf("%s:/var/lib/iib/_hidden/do.not.edit.db", CatalogIndex), "./output/"+versionTag+"/index.db")
 	_, err = pkg.RunCommand(command)
 	if err != nil {
 		log.Infof("unable to extract the image for index.db (transition or file based config index) %s : %s", image, err)
 	}
 	// For FBC extract they are on the image, in /configs/<package_name>/catalog.json
-	command = exec.Command(containerEngine, "cp", fmt.Sprintf("%s:/configs/", catalogIndex),
+	command = exec.Command(containerEngine, "cp", fmt.Sprintf("%s:/configs/", CatalogIndex),
 		"./output/"+versionTag+"/")
 	_, errFbc := pkg.RunCommand(command)
 	if errFbc != nil {


### PR DESCRIPTION
[Fix mis-ordering maxOCP for FBC](https://github.com/operator-framework/audit/pull/149/commits/10dae0beb345c65cdc38744b380341e3f4afc4c0)

[Remove "v" and quotes from all version references](https://github.com/operator-framework/audit/pull/149/commits/2f84d8f02d6e076dc86b217bbbfcc7f303c4249a)